### PR TITLE
Add minimum input validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -60,7 +61,10 @@ func main() {
 		return
 	}
 
-	// todo: validate config
+	if err := validate(c); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
 
 	password := readPassword("Enter password: ")
 	if !c.Open {
@@ -100,6 +104,14 @@ func main() {
 		}
 	}
 
+}
+
+func validate(c config) error {
+	// todo: improve validation
+	if c.File == "" && c.Dir == "" {
+		return errors.New(`target file or directory not specified. Execute "goz -help"`)
+	}
+	return nil
 }
 
 func gozFile(key []byte, filename string, open bool) (err error) {


### PR DESCRIPTION
Hello ! :wave: :hugs: here is a contribution ! 

### Problem

Using the binary without any arguments results in a "no such file directory".

```bash
$ goz 
Enter password: 
Confirm password: 
encrypt: : os.Open: open : no such file or directory
```

### Solution

This fix prevents further execution by showing a user-friendly message.

```bash
$ goz
target file or directory not specified. Execute "goz -help"
```

Probably not the perfect solution :smile: , but could be of help till we improve the validation more. I was also thinking
on using relative paths by default, but probably for a tool like this i prefer to be explicit about target paths :sweat_smile: .
